### PR TITLE
feat: modifiersOnly option

### DIFF
--- a/example/example.config.js
+++ b/example/example.config.js
@@ -41,9 +41,24 @@ const modules = [
     whitelist: ["bd:w", "bd:s", "bd:n"],
     borderStyleValues: ["solid", "dotted"],
     borderWidthValues: ["1px", "2px"],
-    pseudoClasses: { "bd:n": [":hover"] },
     isResponsive: true,
     responsiveWhiteList: ["bd:n"],
+    nestedRules: {
+      "@media (hover: hover) and (pointer: fine)": {
+        names: {
+          "bd:w": "borderWidth",
+          "bd:s": "borderStyle",
+          "bd:n": "borderNone",
+        },
+        whitelist: ["bd:w", "bd:s", "bd:n"],
+        borderStyleValues: ["solid", "dotted"],
+        borderWidthValues: ["1px", "2px"],
+        pseudoClasses: { "bd:n": [":hover"] },
+        isResponsive: true,
+        responsiveWhiteList: ["bd:n"],
+        modifiersOnly: true,
+      },
+    },
   }),
   font({
     names: { fz: "f" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utilitycss/utility",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Generator for Utility CSS frameworks",
   "author": "Andrea Moretti (@axyz) <axyzxp@gmail.com>",
   "repository": "utilitycss/utility",

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export type UtilityConfig<T extends any> = T & {
       }
     | PseudoClass[];
   nestedRules?: any;
+  modifiersOnly?: boolean;
   className?: string;
   property?: string;
   props?: GenericObject;

--- a/src/util/applyRules.ts
+++ b/src/util/applyRules.ts
@@ -25,6 +25,7 @@ const applyRules: ApplyRules<{}> = ({
     responsiveBlackList = [],
     pseudoClasses = {},
     nestedRules,
+    modifiersOnly = false,
   } = config || {};
 
   const {
@@ -61,12 +62,12 @@ const applyRules: ApplyRules<{}> = ({
           pseudoClassesSeparator,
           meta: { ...meta, id: curr },
           classTemplate,
+          modifiersOnly,
         })
       );
     } else if (typeof value === "string" || typeof value === "number") {
-      // FIX ME: WHAT IS this for?
-      // eslint-disable-next-line
-      const singles = [""].concat(modifiers).reduce((prev, pseudo) => {
+      const startingArray = modifiersOnly ? [] : [""];
+      const singles = startingArray.concat(modifiers).reduce((prev, pseudo) => {
         const separator = pseudo !== "" ? pseudoClassesSeparator : "";
         const pseudoClass = pseudo.replace(/:/g, "");
 

--- a/src/util/defineSeries.ts
+++ b/src/util/defineSeries.ts
@@ -8,7 +8,7 @@ type Options = Pick<
   GlobalUtilityConfig,
   "seriesSeparator" | "pseudoClassesSeparator" | "classTemplate"
 > &
-  Pick<UtilityConfig<any>, "pseudoClasses" | "meta">;
+  Partial<Pick<UtilityConfig<any>, "pseudoClasses" | "meta" | "modifiersOnly">>;
 
 type DefineSeries = (
   name: string | number,
@@ -27,11 +27,13 @@ const defineSeries: DefineSeries = (
     seriesSeparator = "",
     pseudoClassesSeparator = "",
     pseudoClasses = [],
+    modifiersOnly = false,
     meta = {},
     classTemplate = "{}",
   } = options;
 
-  return [""].concat(pseudoClasses).reduce((prev, pseudo) => {
+  const startingArray = modifiersOnly ? [] : [""];
+  return startingArray.concat(pseudoClasses).reduce((prev, pseudo) => {
     const pseudoSeparator = pseudo !== "" ? pseudoClassesSeparator : "";
     const separator = name !== "" ? seriesSeparator : "";
     const pseudoClass = pseudo.replace(/:/g, "");


### PR DESCRIPTION
@sylvesteraswin 

- add a `modifiersOnly` option to only render the pseudoClasses (or modifiers in general) in a module, skipping the unmodified base classes.

This can be useful when some classes for examples should exist only for hover or focus, etc... or also to have only pseudoclasses as children of a nested media query (e.g. to disable hover classes on touch devices)